### PR TITLE
FEAT: Add history management

### DIFF
--- a/src/components/InfoSidebar/InfoSidebar.jsx
+++ b/src/components/InfoSidebar/InfoSidebar.jsx
@@ -26,7 +26,7 @@ const InfoSidebar = ({ page, noOfVideos }) => {
           alt="profile"
         />
         <p title="Bablue Tailor" className={styles.userName}>
-          {authState.userName}
+          {authState.user.username}
         </p>
       </div>
     </div>

--- a/src/components/LoginModal/LoginModal.jsx
+++ b/src/components/LoginModal/LoginModal.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAuth, useComponents, useHistory } from "../../context";
+import { useAuth, useComponents, useHistory, useLikes } from "../../context";
 import { guestUser, inputHandler, loginHandler } from "../../utilities";
 import { SignupModal } from "../../components";
 import styles from "./LoginModal.module.css";
@@ -13,6 +13,7 @@ const LoginModal = () => {
   const { authDispatch } = useAuth();
   const { componentsDispatch } = useComponents();
   const { historyDispatch } = useHistory();
+  const { likesDispatch } = useLikes();
 
   return (
     <form
@@ -22,6 +23,7 @@ const LoginModal = () => {
           authDispatch,
           componentsDispatch,
           historyDispatch,
+          likesDispatch,
           event
         )
       }

--- a/src/components/LoginModal/LoginModal.jsx
+++ b/src/components/LoginModal/LoginModal.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAuth, useComponents } from "../../context";
+import { useAuth, useComponents, useHistory } from "../../context";
 import { guestUser, inputHandler, loginHandler } from "../../utilities";
 import { SignupModal } from "../../components";
 import styles from "./LoginModal.module.css";
@@ -12,11 +12,18 @@ const LoginModal = () => {
 
   const { authDispatch } = useAuth();
   const { componentsDispatch } = useComponents();
+  const { historyDispatch } = useHistory();
 
   return (
     <form
       onSubmit={(event) =>
-        loginHandler(login, authDispatch, componentsDispatch, event)
+        loginHandler(
+          login,
+          authDispatch,
+          componentsDispatch,
+          historyDispatch,
+          event
+        )
       }
     >
       <div className="input input__icons input__premium">

--- a/src/components/SmallVideoCard/SmallVideoCard.jsx
+++ b/src/components/SmallVideoCard/SmallVideoCard.jsx
@@ -1,18 +1,27 @@
 import { useState } from "react";
 import { Icon } from "@iconify/react";
-import { useAuth, useLikes, useComponents } from "../../context";
-import { icons, isLiked, likesHandler } from "../../utilities";
-import styles from "./SmallVideoCard.module.css";
 import { Link } from "react-router-dom";
+import { useAuth, useLikes, useComponents, useHistory } from "../../context";
+import {
+  icons,
+  isInHistory,
+  isLiked,
+  likesHandler,
+  removeFromHistoryHandler,
+} from "../../utilities";
+import styles from "./SmallVideoCard.module.css";
 
 const SmallVideoCard = ({ video, page = "" }) => {
   const { authState } = useAuth();
   const { likesState, likesDispatch } = useLikes();
+  const { historyState, historyDispatch } = useHistory();
   const { componentsDispatch } = useComponents();
   const [isPresent, setIsPresent] = useState(() => {
     switch (page) {
       case "liked":
         return isLiked(video, likesState.likes);
+      case "history":
+        return isInHistory(video, historyState.history);
       default:
         return false;
     }
@@ -39,6 +48,12 @@ const SmallVideoCard = ({ video, page = "" }) => {
                     likesDispatch,
                     setIsPresent,
                     video
+                  );
+                case "history":
+                  return removeFromHistoryHandler(
+                    video._id,
+                    historyDispatch,
+                    authState.token
                   );
               }
             }}

--- a/src/context/historyContext.js
+++ b/src/context/historyContext.js
@@ -23,7 +23,7 @@ const HistoryProvider = ({ children }) => {
             const response = await getHistoryService(authState.token);
             historyDispatch({
               type: "INITIAL_HISTORY",
-              payload: response.data.history,
+              payload: { history: response.data.history },
             });
           } catch (error) {
             console.log("ERROR: ", error);

--- a/src/context/historyContext.js
+++ b/src/context/historyContext.js
@@ -1,0 +1,44 @@
+import { createContext, useContext, useReducer, useEffect } from "react";
+import { useAuth } from "../context";
+import { getHistoryService } from "../services";
+import { initialHistoryState, historyReducer } from "../redux";
+
+const HistoryContext = createContext({
+  historyState: {},
+  historyDispatch: () => {},
+});
+
+const HistoryProvider = ({ children }) => {
+  const [historyState, historyDispatch] = useReducer(
+    historyReducer,
+    initialHistoryState
+  );
+
+  const { authState } = useAuth();
+
+  useEffect(() => {
+    authState.token
+      ? (async () => {
+          try {
+            const response = await getHistoryService(authState.token);
+            historyDispatch({
+              type: "INITIAL_HISTORY",
+              payload: response.data.history,
+            });
+          } catch (error) {
+            console.log("ERROR: ", error);
+          }
+        })()
+      : null;
+  }, []);
+
+  return (
+    <HistoryContext.Provider value={{ historyState, historyDispatch }}>
+      {children}
+    </HistoryContext.Provider>
+  );
+};
+
+const useHistory = () => useContext(HistoryContext);
+
+export { HistoryProvider, useHistory };

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -1,4 +1,5 @@
 export { AuthProvider, useAuth } from "./authContext";
 export { ComponentsProvider, useComponents } from "./componentsContext";
 export { DataProvider, useData } from "./dataContext";
+export { HistoryProvider, useHistory } from "./historyContext";
 export { LikesProvider, useLikes } from "./likesContext";

--- a/src/context/likesContext.js
+++ b/src/context/likesContext.js
@@ -23,7 +23,7 @@ const LikesProvider = ({ children }) => {
             const response = await getLikesService(authState.token);
             likesDispatch({
               type: "INITIAL_LIKES",
-              payload: response.data.likes,
+              payload: { likes: response.data.likes },
             });
           } catch (error) {
             console.log("ERROR: ", error);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
   ComponentsProvider,
   LikesProvider,
   DataProvider,
+  HistoryProvider,
 } from "./context";
 import "./index.css";
 import App from "./App";
@@ -21,7 +22,9 @@ ReactDOM.render(
         <DataProvider>
           <ComponentsProvider>
             <LikesProvider>
-              <App />
+              <HistoryProvider>
+                <App />
+              </HistoryProvider>
             </LikesProvider>
           </ComponentsProvider>
         </DataProvider>

--- a/src/redux/historyReducer.js
+++ b/src/redux/historyReducer.js
@@ -1,0 +1,29 @@
+const initialHistoryState = {
+  history: [],
+};
+
+const historyReducer = (historyState, historyAction) => {
+  switch (historyAction.type) {
+    case "INITIAL_HISTORY":
+      return {
+        ...historyState,
+        history: historyAction.payload.history,
+      };
+    case "ADD_TO_HISTORY":
+      return {
+        ...historyState,
+        history: historyAction.payload.history,
+      };
+    case "REMOVE_FROM_HISTORY":
+      return {
+        ...historyState,
+        history: historyAction.payload.history,
+      };
+    case "CLEAR_HISTORY":
+      return initialHistoryState;
+    default:
+      return historyState;
+  }
+};
+
+export { initialHistoryState, historyReducer };

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -1,3 +1,4 @@
 export { initialAuthState, authReducer } from "./authReducer";
 export { initialComponentsState, componentsReducer } from "./componentsReducer";
+export { initialHistoryState, historyReducer } from "./historyReducer";
 export { initialLikesState, likesReducer } from "./likesReducer";

--- a/src/screens/History.jsx
+++ b/src/screens/History.jsx
@@ -1,17 +1,53 @@
+import { Icon } from "@iconify/react";
+import { icons, clearHistoryHandler } from "../utilities";
 import { InfoSidebar, HorizontalCardWrapper } from "../components";
-import { videos } from "../backend/db/videos";
 import styles from "./History.module.css";
+import { useAuth, useHistory } from "../context";
+import { Link } from "react-router-dom";
 
 const History = () => {
-  const videoList = [...videos];
+  const { historyState, historyDispatch } = useHistory();
+  const { authState } = useAuth();
+
   return (
     <section className={styles.body}>
       <div className={styles.headingWrapper}>
         <h2 className={styles.heading}>Your Watch History</h2>
+        <button
+          className={`button btn-solid-danger ${styles.clearBtn} ${
+            historyState.history.length <= 0 ? styles.disabledBtn : null
+          }`}
+          onClick={() => clearHistoryHandler(historyDispatch, authState.token)}
+        >
+          <Icon icon={icons.delete} />
+          Clear History
+        </button>
       </div>
       <div className={styles.historyWrapper}>
-        <InfoSidebar page="Watch History" noOfVideos={videoList.length} />
-        <HorizontalCardWrapper videoList={videoList} page="history" />
+        <InfoSidebar
+          page="Watch History"
+          noOfVideos={historyState.history.length}
+        />
+        {historyState.history.length > 0 ? (
+          <HorizontalCardWrapper
+            videoList={historyState.history}
+            page="history"
+          />
+        ) : (
+          <div className={styles.emptyHistoryMsg}>
+            <p>
+              Why haven't you watched any Video yet? 😲
+              <br />
+              Go watch a few!
+            </p>
+            <br />
+            <Link to="/explore">
+              <button className="button btn-solid-primary">
+                Explore Videos
+              </button>
+            </Link>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/screens/History.jsx
+++ b/src/screens/History.jsx
@@ -1,9 +1,9 @@
 import { Icon } from "@iconify/react";
 import { icons, clearHistoryHandler } from "../utilities";
 import { InfoSidebar, HorizontalCardWrapper } from "../components";
-import styles from "./History.module.css";
 import { useAuth, useHistory } from "../context";
 import { Link } from "react-router-dom";
+import styles from "./History.module.css";
 
 const History = () => {
   const { historyState, historyDispatch } = useHistory();

--- a/src/screens/History.module.css
+++ b/src/screens/History.module.css
@@ -3,12 +3,12 @@
   display: flex;
   justify-content: space-between;
   margin-top: var(--space-md);
+  padding: 0 var(--space-md);
 }
 
 .heading {
   font-size: var(--fs-sm-2);
   font-weight: var(--fw-2);
-  padding: 0 var(--space-md);
 }
 
 .body {
@@ -22,4 +22,30 @@
   gap: var(--space-sm);
   height: calc(100vh - 160px);
   padding: var(--space-md);
+}
+
+.emptyHistoryMsg {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-size: var(--fs-lg-1);
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+}
+
+.clearBtn {
+  align-items: center;
+  display: flex;
+  gap: var(--space-xxxs);
+  padding: var(--space-xxs) var(--space-xs);
+}
+
+.disabledBtn {
+  cursor: not-allowed;
+  background-color: var(--grey-3);
+}
+
+.disabledBtn:hover {
+  background-color: var(--grey-3);
 }

--- a/src/screens/Settings.jsx
+++ b/src/screens/Settings.jsx
@@ -1,11 +1,12 @@
 import { useNavigate } from "react-router";
-import { useAuth, useLikes } from "../context";
+import { useAuth, useHistory, useLikes } from "../context";
 import { logoutHandler } from "../utilities";
 import styles from "./Settings.module.css";
 
 const Settings = () => {
   const { authState, authDispatch } = useAuth();
   const { likesDispatch } = useLikes();
+  const { historyDispatch } = useHistory();
   const navigate = useNavigate();
 
   return (
@@ -15,7 +16,14 @@ const Settings = () => {
           <p className={styles.greet}>Hello, {authState.user.username}👋</p>
           <button
             className="button btn-solid-primary"
-            onClick={() => logoutHandler(authDispatch, likesDispatch, navigate)}
+            onClick={() =>
+              logoutHandler(
+                authDispatch,
+                likesDispatch,
+                historyDispatch,
+                navigate
+              )
+            }
           >
             Logout
           </button>

--- a/src/screens/SingleVideoPage.jsx
+++ b/src/screens/SingleVideoPage.jsx
@@ -1,18 +1,31 @@
-import { useParams } from "react-router-dom";
+import { useState } from "react";
 import { Icon } from "@iconify/react";
-import { icons, isLiked, likesHandler } from "../utilities";
+import { useParams } from "react-router-dom";
 import { HorizontalCardWrapper } from "../components";
 import { videos } from "../backend/db/videos";
-import { useAuth, useComponents, useData, useLikes } from "../context";
+import {
+  addToHistoryHandler,
+  icons,
+  isInHistory,
+  isLiked,
+  likesHandler,
+} from "../utilities";
+import {
+  useAuth,
+  useComponents,
+  useData,
+  useHistory,
+  useLikes,
+} from "../context";
 import styles from "./SingleVideoPage.module.css";
-import { useState } from "react";
 
 const SingleVideoPage = () => {
   const { videosData } = useData();
-  const { likesState, likesDispatch } = useLikes();
+  const { videoID } = useParams();
   const { authState } = useAuth();
   const { componentsDispatch } = useComponents();
-  const { videoID } = useParams();
+  const { likesState, likesDispatch } = useLikes();
+  const { historyState, historyDispatch } = useHistory();
 
   const videoList = videos.slice(8, 22);
   const video = videosData.find((currVideo) => currVideo.youtubeID === videoID);
@@ -30,6 +43,14 @@ const SingleVideoPage = () => {
   const [isVideoLiked, setIsVideoLiked] = useState(
     isLiked(video, likesState.likes)
   );
+  const [inHistory, setInHistory] = useState(
+    isInHistory(video, historyState.history)
+  );
+
+  if (!inHistory) {
+    addToHistoryHandler(video, historyDispatch, authState.token);
+    setInHistory(true);
+  }
 
   return (
     <section className={styles.singleVideoPage}>

--- a/src/services/addToHistory.service.js
+++ b/src/services/addToHistory.service.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+const addToHistoryService = (video, token) => {
+  return axios.post(
+    "/api/user/history",
+    { video },
+    {
+      headers: { authorization: token },
+    }
+  );
+};
+
+export { addToHistoryService };

--- a/src/services/clearHistory.service.js
+++ b/src/services/clearHistory.service.js
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const clearHistoryService = (token) => {
+  return axios.delete("/api/user/history/all", {
+    headers: { authorization: token },
+  });
+};
+
+export { clearHistoryService };

--- a/src/services/getHistory.service.js
+++ b/src/services/getHistory.service.js
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const getHistoryService = (token) => {
+  return axios.get("/api/user/history", {
+    headers: { authorization: token },
+  });
+};
+
+export { getHistoryService };

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,6 +1,10 @@
+export { addToHistoryService } from "./addToHistory.service";
 export { addToLikesService } from "./addToLikes.service";
+export { clearHistoryService } from "./clearHistory.service";
+export { getHistoryService } from "./getHistory.service";
 export { getLikesService } from "./getLikes.service";
 export { getVideosService } from "./getVideos.service";
 export { loginService } from "./login.service";
+export { removeFromHistoryService } from "./removeFromHistory.service";
 export { removeFromLikesService } from "./removeFromLikes.service";
 export { signupService } from "./signup.service";

--- a/src/services/removeFromHistory.service.js
+++ b/src/services/removeFromHistory.service.js
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const removeFromHistoryService = (videoId, token) => {
+  return axios.delete(`/api/user/history/${videoId}`, {
+    headers: { authorization: token },
+  });
+};
+
+export { removeFromHistoryService };

--- a/src/utilities/addToHistoryHandler.js
+++ b/src/utilities/addToHistoryHandler.js
@@ -1,0 +1,22 @@
+import { addToHistoryService } from "../services";
+
+const addToHistoryHandler = async (video, historyDispatch, token) => {
+  try {
+    const response = await addToHistoryService(video, token);
+    console.log(response);
+    if (response.status === 201) {
+      historyDispatch({
+        type: "ADD_TO_HISTORY",
+        payload: {
+          history: response.data.history.reverse(),
+        },
+      });
+    } else {
+      throw new Error("Something went wrong. Please try again later!");
+    }
+  } catch (error) {
+    console.log("Error in add history handler", error);
+  }
+};
+
+export { addToHistoryHandler };

--- a/src/utilities/clearHistoryHandler.js
+++ b/src/utilities/clearHistoryHandler.js
@@ -1,0 +1,18 @@
+import { clearHistoryService } from "../services";
+
+const clearHistoryHandler = async (historyDispatch, token) => {
+  try {
+    const response = await clearHistoryService(token);
+    if (response.status === 200) {
+      historyDispatch({
+        type: "CLEAR_HISTORY",
+      });
+    } else {
+      throw new Error("Something went wrong. Please try again later");
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export { clearHistoryHandler };

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,11 +1,15 @@
+export { addToHistoryHandler } from "./addToHistoryHandler";
 export { addToLikesHandler } from "./addToLikesHandler";
+export { clearHistoryHandler } from "./clearHistoryHandler";
 export { guestUser } from "./guestUser";
 export { icons } from "./icons";
 export { inputHandler } from "./inputHandler";
+export { isInHistory } from "./isInHistory";
 export { isLiked } from "./isLiked";
 export { likesHandler } from "./likesHandler";
 export { loginHandler } from "./loginHandler";
 export { logoutHandler } from "./logoutHandler";
+export { removeFromHistoryHandler } from "./removeFromHistoryHandler";
 export { removeFromLikesHandler } from "./removeFromLikesHandler";
 export { signupHandler } from "./signupHandler";
 export { tabsList } from "./tabsList";

--- a/src/utilities/isInHistory.js
+++ b/src/utilities/isInHistory.js
@@ -1,0 +1,7 @@
+const isInHistory = (video, historyVideos) => {
+  return historyVideos.find((currVideo) => currVideo._id === video._id)
+    ? true
+    : false;
+};
+
+export { isInHistory };

--- a/src/utilities/loginHandler.js
+++ b/src/utilities/loginHandler.js
@@ -1,20 +1,32 @@
-import { loginService } from "../services";
+import { loginService, getHistoryService } from "../services";
 
-const loginHandler = async (login, authDispatch, componentsDispatch, event) => {
+const loginHandler = async (
+  login,
+  authDispatch,
+  componentsDispatch,
+  historyDispatch,
+  event
+) => {
   try {
     event.preventDefault();
     const response = await loginService(login);
     if (response.status === 200) {
       localStorage.setItem("token", response.data.encodedToken);
-      localStorage.setItem(
-        "user",
-        JSON.stringify(response.data.foundUser)
-      );
+      localStorage.setItem("user", JSON.stringify(response.data.foundUser));
       authDispatch({
         type: "LOGIN",
         payload: {
           token: response.data.encodedToken,
           user: response.data.foundUser,
+        },
+      });
+      const responseHistory = await getHistoryService(
+        response.data.encodedToken
+      );
+      historyDispatch({
+        type: "INITIAL_HISTORY",
+        payload: {
+          history: responseHistory.data.history,
         },
       });
       componentsDispatch({
@@ -24,7 +36,7 @@ const loginHandler = async (login, authDispatch, componentsDispatch, event) => {
           child: "",
           title: "",
         },
-      })
+      });
       alert("Login Successful");
     }
     if (response.status === 404) {

--- a/src/utilities/loginHandler.js
+++ b/src/utilities/loginHandler.js
@@ -1,10 +1,11 @@
-import { loginService, getHistoryService } from "../services";
+import { loginService, getHistoryService, getLikesService } from "../services";
 
 const loginHandler = async (
   login,
   authDispatch,
   componentsDispatch,
   historyDispatch,
+  likesDispatch,
   event
 ) => {
   try {
@@ -27,6 +28,13 @@ const loginHandler = async (
         type: "INITIAL_HISTORY",
         payload: {
           history: responseHistory.data.history,
+        },
+      });
+      const responseLikes = await getLikesService(response.data.encodedToken);
+      likesDispatch({
+        type: "INITIAL_LIKES",
+        payload: {
+          likes: responseLikes.data.likes,
         },
       });
       componentsDispatch({

--- a/src/utilities/logoutHandler.js
+++ b/src/utilities/logoutHandler.js
@@ -1,4 +1,4 @@
-const logoutHandler = (authDispatch, likesDispatch, navigate) => {
+const logoutHandler = (authDispatch, likesDispatch, historyDispatch, navigate) => {
   localStorage.removeItem("token");
   localStorage.removeItem("user");
   authDispatch({
@@ -6,6 +6,9 @@ const logoutHandler = (authDispatch, likesDispatch, navigate) => {
   });
   likesDispatch({
     type: "RESET_LIKES",
+  });
+  historyDispatch({
+    type: "CLEAR_HISTORY",
   });
   alert("Logout Successful");
   navigate("/");

--- a/src/utilities/removeFromHistoryHandler.js
+++ b/src/utilities/removeFromHistoryHandler.js
@@ -1,0 +1,21 @@
+import { removeFromHistoryService } from "../services";
+
+const removeFromHistoryHandler = async (videoId, historyDispatch, token) => {
+  try {
+    const response = await removeFromHistoryService(videoId, token);
+    if (response.status === 200) {
+      historyDispatch({
+        type: "REMOVE_FROM_HISTORY",
+        payload: {
+          history: response.data.history.reverse(),
+        },
+      });
+    } else {
+      throw new Error("Something went wrong. Please try again later");
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export { removeFromHistoryHandler };


### PR DESCRIPTION
### 📝 Description

A history page is where the user can see all the history of videos that they have watched.

### 🚀 New behavior

- Any video that the user watches gets added to the history
- History is visible from the history page
- User can remove one video from history
- User can also clear the whole history at once

### 🖼 Preview Link

[https://vistream-react-version-9o9w8536m-vishalpatil18.vercel.app/](https://vistream-react-version-9o9w8536m-vishalpatil18.vercel.app/)

### 💣 Is this a breaking change?
- [ ] Yes
- [x] No

### 🔬 Is the code self-reviewed?
- [x] Yes
- [ ] No

### 📋 Is the code well-formatted?
- [x] Yes
- [ ] No


### 🔗 Related to Issue
- #15 

> NOTE: The site is not responsive yet. I will work on responsiveness at the end.
