### PR TITLE
FEAT: Add Watchlater management

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,7 +30,7 @@ function App() {
       {componentsState.alert.active ? <>{componentsState.alert.child}</> : null}
 
       <Drawer />
-      <section className={styles.mainBody}>
+      <section className={styles.mainBody} id="mainBody">
         <GreetingCard />
         <Routes>
           <Route path="/" element={<Home cname={styles.mainContent} />} />

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -20,7 +20,6 @@
 
 .mainContent {
   height: fit-content;
-  margin-top: var(--space-xxs);
 }
 
 /*

--- a/src/backend/controllers/AuthController.js
+++ b/src/backend/controllers/AuthController.js
@@ -38,6 +38,7 @@ export const signupHandler = function (schema, request) {
       likes: [],
       history: [],
       playlists: [],
+      watchlater: [],
     };
     const createdUser = schema.users.create(newUser);
     const encodedToken = sign({ _id, email }, process.env.REACT_APP_JWT_SECRET);
@@ -83,7 +84,7 @@ export const loginHandler = function (schema, request) {
       {},
       {
         errors: [
-          "Incorrect Password!",
+          "The credentials you entered are invalid. Unauthorized access error.",
         ],
       }
     );

--- a/src/backend/controllers/WatchLaterController.js
+++ b/src/backend/controllers/WatchLaterController.js
@@ -1,0 +1,90 @@
+import { Response } from "miragejs";
+import { requiresAuth } from "../utils/authUtils";
+
+/**
+ * All the routes related to Watch Later Videos are present here.
+ * These are private routes.
+ * Client needs to add "authorization" header with JWT token in it to access it.
+ * */
+
+/**
+ * This handler handles getting videos from user's watchlater playlist.
+ * send GET Request at /api/user/watchlater
+ * */
+
+export const getWatchLaterVideosHandler = function (schema, request) {
+  const user = requiresAuth.call(this, request);
+  try {
+    if (!user) {
+      return new Response(
+        404,
+        {},
+        {
+          errors: ["The email you entered is not Registered. Not Found error"],
+        }
+      );
+    }
+    return new Response(200, {}, { watchlater: user.watchlater });
+  } catch (error) {
+    return new Response(
+      500,
+      {},
+      {
+        error,
+      }
+    );
+  }
+};
+
+/**
+ * This handler handles adding videos to user's watchlater playlist.
+ * send POST Request at /api/user/watchlater
+ * body contains {video}
+ * */
+
+export const addItemToWatchLaterVideos = function (schema, request) {
+  const user = requiresAuth.call(this, request);
+  if (user) {
+    const { video } = JSON.parse(request.requestBody);
+    if (user.watchlater.some((item) => item.id === video.id)) {
+      return new Response(
+        409,
+        {},
+        {
+          errors: ["The video is already in your watch later videos"],
+        }
+      );
+    }
+    user.watchlater.push(video);
+    return new Response(201, {}, { watchlater: user.watchlater });
+  }
+  return new Response(
+    404,
+    {},
+    {
+      errors: ["The email you entered is not Registered. Not Found error"],
+    }
+  );
+};
+
+/**
+ * This handler handles removing videos from user's watchlater playlist.
+ * send DELETE Request at /api/user/watchlater/:videoId
+ * */
+
+export const removeItemFromWatchLaterVideos = function (schema, request) {
+  const user = requiresAuth.call(this, request);
+  if (user) {
+    const videoId = request.params.videoId;
+    const filteredVideos = user.watchlater.filter(
+      (item) => item._id !== videoId
+    );
+    this.db.users.update({ watchlater: filteredVideos });
+    return new Response(200, {}, { watchlater: filteredVideos });
+  }
+  return new Response(
+    404,
+    {},
+    { errors: ["The user you request does not exist. Not Found error."] }
+  );
+};

--- a/src/components/CategoryCarousel/CategoryCarousel.module.css
+++ b/src/components/CategoryCarousel/CategoryCarousel.module.css
@@ -2,7 +2,6 @@
   align-items: center;
   display: flex;
   justify-content: space-between;
-  margin-top: var(--space-lg);
 }
 
 .heading {

--- a/src/components/Drawer/Drawer.jsx
+++ b/src/components/Drawer/Drawer.jsx
@@ -45,7 +45,7 @@ const Drawer = () => {
           </button>
         ) : (
           <button
-            className={`button btn-round ${styles.loginBtn}`}
+            className={`button btn-round ${styles.profileBadge}`}
             onClick={() =>
               componentsDispatch({
                 type: "MODAL",
@@ -63,14 +63,14 @@ const Drawer = () => {
         )}
       </div>
       <div className={styles.mobileDrawer}>
-        <button className={currPage === "/" && styles.active}>
+        <button className={currPage === "/" ? styles.active : null}>
           <Link to="/">
             <Icon icon={icons.home} />
           </Link>
         </button>
         <button
           className={`${styles.largeBtn} ${
-            currPage === "/explore" && styles.active
+            currPage === "/explore" ? styles.active : null
           }`}
         >
           <Link to="/explore">
@@ -78,14 +78,14 @@ const Drawer = () => {
           </Link>
         </button>
         {authState.token ? (
-          <button className={currPage === "/watchlater" && styles.active}>
+          <button className={currPage === "/watchlater" ? styles.active : null}>
             <Link to="/watchlater">
               <Icon icon={icons.bookmarked} />
             </Link>
           </button>
         ) : (
           <button
-            className={currPage === "/watchlater" && styles.active}
+            className={currPage === "/watchlater" ? styles.active : null}
             onClick={() =>
               componentsDispatch({
                 type: "MODAL",
@@ -101,7 +101,7 @@ const Drawer = () => {
           </button>
         )}
         {authState.user ? (
-          <button className={currPage === "/settings" && styles.active}>
+          <button className={currPage === "/settings" ? styles.active : null}>
             <Link to="/settings">
               <Icon icon={icons.settings} />
             </Link>

--- a/src/components/Drawer/Drawer.module.css
+++ b/src/components/Drawer/Drawer.module.css
@@ -45,22 +45,17 @@
 
 .profileBadge {
   align-items: center;
-  background-color: #eb1463;
-  box-shadow: 0 2px 20px 0 rgba(235, 20, 99, 0.8);
   display: flex;
   font-size: var(--fs-md-2);
-  gap: var(--space-xs);
-  margin-top: auto;
-  padding: var(--space-xxs);
-}
-
-.profileBadge:hover {
-  box-shadow: 0 5px 30px 0 rgba(235, 20, 99, 0.95);
+  gap: var(--space-xxs);
+  margin: auto auto 0;
+  padding: var(--space-xxxs) var(--space-md) var(--space-xxxs) var(--space-xxxs);
+  width: fit-content;
 }
 
 .profileBadge > a {
   align-items: center;
-  color: white;
+  color: var(--dark);
   display: flex;
   gap: var(--space-xs);
 }
@@ -73,19 +68,6 @@
   height: var(--space-xl);
   padding: var(--space-xxxs);
   width: var(--space-xl);
-}
-
-.loginBtn {
-  align-items: center;
-  display: flex;
-  font-size: var(--fs-md-2);
-  gap: var(--space-xxxs);
-  justify-content: center;
-  margin-top: auto;
-}
-
-.loginBtn > svg {
-  font-size: var(--fs-lg-2);
 }
 
 .mobileDrawer {

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -9,13 +9,9 @@ const filters = [
 ];
 import styles from "./FilterTags.module.css";
 
-const FilterTags = ({ page }) => {
+const FilterTags = () => {
   return (
-    <div
-      className={`${styles.filtersWrapper}  ${
-        page === "homePage" ? styles.homePage : null
-      }`}
-    >
+    <div className={styles.filtersWrapper}>
       {filters.map((item, i) => (
         <span key={i} className={`chip ch--primary ${styles.chip}`}>
           {item}

--- a/src/components/FilterTags/FilterTags.module.css
+++ b/src/components/FilterTags/FilterTags.module.css
@@ -7,10 +7,6 @@
   scrollbar-width: none;
 }
 
-.homePage {
-  padding: 0 var(--space-md) 0;
-}
-
 .filtersWrapper::-webkit-scrollbar {
   display: none;
 }

--- a/src/components/LoginModal/LoginModal.jsx
+++ b/src/components/LoginModal/LoginModal.jsx
@@ -5,6 +5,7 @@ import {
   useHistory,
   useLikes,
   usePlaylists,
+  useWatchlater,
 } from "../../context";
 import { guestUser, inputHandler, loginHandler } from "../../utilities";
 import { SignupModal } from "../../components";
@@ -21,6 +22,7 @@ const LoginModal = () => {
   const { historyDispatch } = useHistory();
   const { likesDispatch } = useLikes();
   const { playlistsDispatch } = usePlaylists();
+  const { watchlaterDispatch } = useWatchlater();
 
   return (
     <form
@@ -32,6 +34,7 @@ const LoginModal = () => {
           historyDispatch,
           likesDispatch,
           playlistsDispatch,
+          watchlaterDispatch,
           event
         )
       }

--- a/src/components/MainVideoCard/MainVideoCard.jsx
+++ b/src/components/MainVideoCard/MainVideoCard.jsx
@@ -1,18 +1,28 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { Icon } from "@iconify/react";
 import useOnclickOutside from "react-cool-onclickoutside";
-import { useAuth, useLikes, useComponents } from "../../context";
-import { icons, isLiked, likesHandler } from "../../utilities";
+import { useAuth, useLikes, useComponents, useWatchlater } from "../../context";
+import {
+  icons,
+  isLiked,
+  likesHandler,
+  isInWatchlater,
+  watchlaterHandler,
+} from "../../utilities";
 import { PlaylistMenu, LoginModal } from "../../components";
-import { Link } from "react-router-dom";
 import styles from "./MainVideoCard.module.css";
 
 const MainVideoCard = ({ video }) => {
   const { authState } = useAuth();
   const { likesState, likesDispatch } = useLikes();
+  const { watchlaterState, watchlaterDispatch } = useWatchlater();
   const { componentsDispatch } = useComponents();
   const [isOpen, setIsOpen] = useState(false);
   const [isVideoLiked, setIsLiked] = useState(isLiked(video, likesState.likes));
+  const [inWatchlater, setInWatchlater] = useState(
+    isInWatchlater(video, watchlaterState.watchlater)
+  );
 
   const ref = useOnclickOutside(() => {
     setIsOpen(false);
@@ -44,8 +54,23 @@ const MainVideoCard = ({ video }) => {
             >
               <Icon icon={isVideoLiked ? icons.liked : icons.like} />
             </button>
-            <button className={styles.button}>
-              <Icon icon={icons.bookmark} />
+            <button
+              className={`${styles.button} ${
+                inWatchlater ? styles.liked : null
+              }`}
+              onClick={() =>
+                watchlaterHandler(
+                  authState.token,
+                  componentsDispatch,
+                  watchlaterDispatch,
+                  inWatchlater,
+                  setInWatchlater,
+                  video,
+                  ""
+                )
+              }
+            >
+              <Icon icon={inWatchlater ? icons.bookmarked : icons.bookmark} />
             </button>
             <button
               className={styles.button}

--- a/src/components/SmallVideoCard/SmallVideoCard.jsx
+++ b/src/components/SmallVideoCard/SmallVideoCard.jsx
@@ -9,13 +9,16 @@ import {
   useComponents,
   useHistory,
   usePlaylists,
+  useWatchlater,
 } from "../../context";
 import {
   icons,
   isLiked,
+  isInWatchlater,
   likesHandler,
   removeFromHistoryHandler,
   removeVideoFromPlaylistsHandler,
+  watchlaterHandler,
 } from "../../utilities";
 import styles from "./SmallVideoCard.module.css";
 
@@ -25,9 +28,13 @@ const SmallVideoCard = ({ video, page = "", playlistID = "" }) => {
   const { historyDispatch } = useHistory();
   const { componentsDispatch } = useComponents();
   const { playlistsDispatch } = usePlaylists();
+  const { watchlaterState, watchlaterDispatch } = useWatchlater();
   const [isPlaylistMenuOpen, setIsPlaylistMenuOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isVideoLiked, setIsLiked] = useState(isLiked(video, likesState.likes));
+  const [inWatchlater, setInWatchlater] = useState(
+    isInWatchlater(video, watchlaterState.watchlater)
+  );
 
   const ref = useOnclickOutside(() => {
     setIsPlaylistMenuOpen(false);
@@ -77,12 +84,26 @@ const SmallVideoCard = ({ video, page = "", playlistID = "" }) => {
                       componentsDispatch,
                       authState.token
                     );
+                  case "watchlater":
+                    return watchlaterHandler(
+                      authState.token,
+                      componentsDispatch,
+                      watchlaterDispatch,
+                      inWatchlater,
+                      setInWatchlater,
+                      video,
+                      page
+                    );
                 }
               }}
             >
               <Icon
                 icon={(() => {
-                  if (page === "liked" && isVideoLiked) return icons.delete;
+                  if (
+                    (page === "liked" && isVideoLiked) ||
+                    (page === "watchlater" && inWatchlater)
+                  )
+                    return icons.delete;
                   else {
                     switch (page) {
                       case "liked":
@@ -98,7 +119,9 @@ const SmallVideoCard = ({ video, page = "", playlistID = "" }) => {
                 })()}
                 className={styles.menuActionBtnIcon}
               />
-              {(page === "liked" && isVideoLiked) || true
+              {(page === "liked" && isVideoLiked) ||
+              (page === "watchlater" && inWatchlater) ||
+              true
                 ? `Remove from ${page}`
                 : `Add to ${page}`}
             </button>

--- a/src/components/WatchlaterVideos/WatchlaterVideos.jsx
+++ b/src/components/WatchlaterVideos/WatchlaterVideos.jsx
@@ -1,10 +1,10 @@
 import { Link } from "react-router-dom";
 import { SmallVideoCard } from "../../components";
-import { videos } from "../../backend/db/videos";
+import { useWatchlater } from "../../context";
 import styles from "./WatchlaterVideos.module.css";
 
 const WatchlaterVideos = () => {
-  const videoList = videos.slice(0, 4);
+  const { watchlaterState } = useWatchlater();
 
   return (
     <section>
@@ -19,13 +19,15 @@ const WatchlaterVideos = () => {
         </Link>
       </div>
       <div className={styles.table}>
-        {videoList.map((video) => (
-          <SmallVideoCard
-            key={`watchLaterVideo-${video._id}`}
-            video={video}
-            page="watchlater"
-          />
-        ))}
+        {watchlaterState.watchlater.length > 0
+          ? watchlaterState.watchlater.map((video) => (
+              <SmallVideoCard
+                key={`watchLaterVideo-${video._id}`}
+                video={video}
+                page="watchlater"
+              />
+            ))
+          : null}
       </div>
     </section>
   );

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -4,3 +4,4 @@ export { DataProvider, useData } from "./dataContext";
 export { HistoryProvider, useHistory } from "./historyContext";
 export { LikesProvider, useLikes } from "./likesContext";
 export { PlaylistsProvider, usePlaylists } from "./playlistContext";
+export { WatchlaterProvider, useWatchlater } from "./watchlaterContext";

--- a/src/context/watchlaterContext.js
+++ b/src/context/watchlaterContext.js
@@ -1,0 +1,48 @@
+import { createContext, useContext, useReducer, useEffect } from "react";
+import { watchlaterReducer, initialWatchlaterState } from "../redux";
+import { useAuth } from "../context";
+import { getWatchlaterService } from "../services";
+
+const WatchlaterContext = createContext({
+  watchlaterState: {},
+  watchlaterDispatch: () => {},
+});
+
+const WatchlaterProvider = ({ children }) => {
+  const [watchlaterState, watchlaterDispatch] = useReducer(
+    watchlaterReducer,
+    initialWatchlaterState
+  );
+
+  const { authState } = useAuth();
+
+  useEffect(() => {
+    authState.token
+      ? (async () => {
+          try {
+            const response = await getWatchlaterService(authState.token);
+            if (response.status === 201) {
+              watchlaterDispatch({
+                type: "INITIAL_WATCHLATER",
+                payload: { watchlater: response.data.watchlater },
+              });
+            } else {
+              throw new Error("Something went wrong! Please try again later");
+            }
+          } catch (error) {
+            console.log("ERROR: ", error);
+          }
+        })()
+      : null;
+  }, []);
+
+  return (
+    <WatchlaterContext.Provider value={{ watchlaterState, watchlaterDispatch }}>
+      {children}
+    </WatchlaterContext.Provider>
+  );
+};
+
+const useWatchlater = () => useContext(WatchlaterContext);
+
+export { WatchlaterProvider, useWatchlater };

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import {
   DataProvider,
   HistoryProvider,
   PlaylistsProvider,
+  WatchlaterProvider,
 } from "./context";
 import "./index.css";
 import App from "./App";
@@ -18,21 +19,23 @@ makeServer();
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <ComponentsProvider>
-        <AuthProvider>
-          <DataProvider>
-            <LikesProvider>
-              <HistoryProvider>
-                <PlaylistsProvider>
-                  <App />
-                </PlaylistsProvider>
-              </HistoryProvider>
-            </LikesProvider>
-          </DataProvider>
-        </AuthProvider>
-      </ComponentsProvider>
-    </BrowserRouter>
+    <AuthProvider>
+      <DataProvider>
+        <LikesProvider>
+          <HistoryProvider>
+            <PlaylistsProvider>
+              <WatchlaterProvider>
+                <ComponentsProvider>
+                  <BrowserRouter>
+                    <App />
+                  </BrowserRouter>
+                </ComponentsProvider>
+              </WatchlaterProvider>
+            </PlaylistsProvider>
+          </HistoryProvider>
+        </LikesProvider>
+      </DataProvider>
+    </AuthProvider>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -3,3 +3,4 @@ export { initialComponentsState, componentsReducer } from "./componentsReducer";
 export { initialHistoryState, historyReducer } from "./historyReducer";
 export { initialLikesState, likesReducer } from "./likesReducer";
 export { initialPlaylistsState, playlistsReducer } from "./playlistReducer";
+export { initialWatchlaterState, watchlaterReducer } from "./watchlaterReducer";

--- a/src/redux/watchlaterReducer.js
+++ b/src/redux/watchlaterReducer.js
@@ -1,0 +1,29 @@
+const initialWatchlaterState = {
+  watchlater: [],
+};
+
+const watchlaterReducer = (watchlaterState, watchlaterAction) => {
+  switch (watchlaterAction.type) {
+    case "INITIAL_WATCHLATER":
+      return {
+        ...watchlaterState,
+        watchlater: watchlaterAction.payload.watchlater,
+      };
+    case "ADD_TO_WATCHLATER":
+      return {
+        ...watchlaterState,
+        watchlater: watchlaterAction.payload.watchlater,
+      };
+    case "REMOVE_FROM_WATCHLATER":
+      return {
+        ...watchlaterState,
+        watchlater: watchlaterAction.payload.watchlater,
+      };
+    case "RESET_WATCHLATER":
+      return initialWatchlaterState;
+    default:
+      return watchlaterState;
+  }
+};
+
+export { initialWatchlaterState, watchlaterReducer };

--- a/src/screens/Explore.jsx
+++ b/src/screens/Explore.jsx
@@ -1,9 +1,12 @@
 import { Icon } from "@iconify/react";
+import { useEffect } from "react";
 import { FeaturedVideos, FilterTags } from "../components";
-import { icons } from "../utilities";
+import { icons, scrollToTop } from "../utilities";
 import styles from "./Explore.module.css";
 
 const Explore = () => {
+  useEffect(scrollToTop, []);
+
   return (
     <main>
       <div className={styles.header}>

--- a/src/screens/History.jsx
+++ b/src/screens/History.jsx
@@ -1,10 +1,14 @@
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
 import { InfoSidebar, HorizontalCardWrapper } from "../components";
 import { useHistory } from "../context";
-import { Link } from "react-router-dom";
+import { scrollToTop } from "../utilities";
 import styles from "./History.module.css";
 
 const History = () => {
   const { historyState } = useHistory();
+
+  useEffect(scrollToTop, []);
 
   return (
     <section className={styles.body}>

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -1,28 +1,30 @@
+import { Link } from "react-router-dom";
+import { useEffect } from "react";
 import {
   CategoryCarousel,
   PlaylistCarousel,
-  FilterTags,
   TrendingVideoTable,
   WatchlaterVideos,
   FeaturedVideos,
-  Alert,
 } from "../components";
-import { Link } from "react-router-dom";
-import { usePlaylists } from "../context";
+import { scrollToTop } from "../utilities";
+import { usePlaylists, useWatchlater } from "../context";
 import styles from "./Home.module.css";
 
 const Home = ({ cname }) => {
   const { playlistsState } = usePlaylists();
+  const { watchlaterState } = useWatchlater();
+
+  useEffect(scrollToTop, []);
 
   return (
     <main className={cname}>
-      <FilterTags page={"homePage"} />
       <CategoryCarousel />
       {playlistsState.playlists.length > 0 ? (
         <PlaylistCarousel playlists={playlistsState.playlists} />
       ) : null}
       <TrendingVideoTable />
-      <WatchlaterVideos />
+      {watchlaterState.watchlater.length > 0 ? <WatchlaterVideos /> : null}
       <FeaturedVideos page="homePage" />
       <footer className={styles.footer}>
         <Link

--- a/src/screens/Liked.jsx
+++ b/src/screens/Liked.jsx
@@ -1,10 +1,14 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { InfoSidebar, HorizontalCardWrapper } from "../components";
 import { useLikes } from "../context";
+import { scrollToTop } from "../utilities";
 import styles from "./Liked.module.css";
 
 const Liked = () => {
   const { likesState } = useLikes();
+
+  useEffect(scrollToTop, []);
 
   return (
     <section className={styles.body}>

--- a/src/screens/Playlist.jsx
+++ b/src/screens/Playlist.jsx
@@ -1,14 +1,16 @@
+import { useEffect, useState } from "react";
 import { PlaylistCard, CreatePlaylistModal } from "../components";
 import { Icon } from "@iconify/react";
-import { icons } from "../utilities";
+import { icons, scrollToTop } from "../utilities";
 import { useComponents, usePlaylists } from "../context";
 import styles from "./Playlist.module.css";
-import { useEffect, useState } from "react";
 
 const Playlist = () => {
   const [playlists, setPlaylists] = useState([]);
   const { playlistsState } = usePlaylists();
   const { componentsDispatch } = useComponents();
+
+  useEffect(scrollToTop, []);
 
   useEffect(() => {
     setPlaylists(Object.values(playlistsState.playlists));

--- a/src/screens/Settings.jsx
+++ b/src/screens/Settings.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useNavigate } from "react-router";
 import {
@@ -6,8 +7,9 @@ import {
   useHistory,
   useLikes,
   usePlaylists,
+  useWatchlater,
 } from "../context";
-import { icons, logoutHandler } from "../utilities";
+import { icons, logoutHandler, scrollToTop } from "../utilities";
 import styles from "./Settings.module.css";
 import { Icon } from "@iconify/react";
 
@@ -17,7 +19,10 @@ const Settings = () => {
   const { historyDispatch } = useHistory();
   const { playlistsDispatch } = usePlaylists();
   const { componentsDispatch } = useComponents();
+  const { watchlaterDispatch } = useWatchlater();
   const navigate = useNavigate();
+
+  useEffect(scrollToTop, []);
 
   return (
     <section className={styles.settings}>
@@ -34,6 +39,7 @@ const Settings = () => {
                   historyDispatch,
                   playlistsDispatch,
                   componentsDispatch,
+                  watchlaterDispatch,
                   navigate
                 )
               }

--- a/src/screens/SinglePlaylistPage.jsx
+++ b/src/screens/SinglePlaylistPage.jsx
@@ -1,7 +1,9 @@
+import { useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
 import { InfoSidebar, HorizontalCardWrapper } from "../components";
-import { useParams } from "react-router-dom";
-import styles from "./SinglePlaylistPage.module.css";
 import { usePlaylists } from "../context";
+import { scrollToTop } from "../utilities";
+import styles from "./SinglePlaylistPage.module.css";
 
 const SinglePlaylistPage = () => {
   const { playlistID } = useParams();
@@ -10,17 +12,36 @@ const SinglePlaylistPage = () => {
   const playlist = playlistsState.playlists.find(
     (currPlaylist) => currPlaylist._id === playlistID
   );
-  const { _id, title, description, videos } = playlist;
+  const { title, videos } = playlist;
+
+  useEffect(scrollToTop, []);
 
   return (
     <section className={styles.body}>
       <div className={styles.playlistWrapper}>
         <InfoSidebar page={title} noOfVideos={videos.length} />
-        <HorizontalCardWrapper
-          videoList={videos}
-          page="playlist"
-          playlistID={playlistID}
-        />
+        {videos.length > 0 ? (
+          <HorizontalCardWrapper
+            videoList={videos}
+            page="playlist"
+            playlistID={playlistID}
+          />
+        ) : (
+          <div className={styles.emptyPlaylistMsgWrapper}>
+            <p className={styles.emptyPlaylistMsg}>
+              I'm useless😓
+              <br />
+              Add Videos in me to make me useful
+              <br />
+              🙃
+            </p>
+            <Link to="/explore">
+              <button className="button btn-solid-primary">
+                Explore Videos
+              </button>
+            </Link>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/screens/SinglePlaylistPage.module.css
+++ b/src/screens/SinglePlaylistPage.module.css
@@ -10,3 +10,41 @@
   height: calc(100vh - 160px);
   padding: var(--space-md);
 }
+
+.emptyPlaylistMsg {
+  align-items: center;
+  display: flex;
+  font-size: var(--fs-lg-1);
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+}
+
+.emptyPlaylistMsgWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.emptyPlaylistMsgWrapper > a {
+  margin: auto;
+}
+
+/*
+***************** MEDIA QUERIES *****************
+*/
+@media screen and (max-width: 1024px) {
+  .playlistWrapper {
+    flex-direction: column;
+    height: fit-content;
+  }
+
+  .body {
+    height: fit-content;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .playlistWrapper {
+    padding: var(--space-xs);
+  }
+}

--- a/src/screens/SingleVideoPage.jsx
+++ b/src/screens/SingleVideoPage.jsx
@@ -10,8 +10,17 @@ import {
   isLiked,
   likesHandler,
   getSingleVideoHandler,
+  isInWatchlater,
+  watchlaterHandler,
+  scrollToTop,
 } from "../utilities";
-import { useAuth, useComponents, useHistory, useLikes } from "../context";
+import {
+  useAuth,
+  useComponents,
+  useHistory,
+  useLikes,
+  useWatchlater,
+} from "../context";
 import styles from "./SingleVideoPage.module.css";
 
 const SingleVideoPage = () => {
@@ -20,20 +29,28 @@ const SingleVideoPage = () => {
   const { componentsDispatch } = useComponents();
   const { historyDispatch } = useHistory();
   const { likesState, likesDispatch } = useLikes();
+  const { watchlaterState, watchlaterDispatch } = useWatchlater();
   const [isPlaylistMenuOpen, setIsPlaylistMenuOpen] = useState(false);
   const [video, setVideo] = useState({});
   const videoList = videos.slice(8, 22);
   const [isVideoLiked, setIsLiked] = useState(false);
+  const [inWatchlater, setInWatchlater] = useState(false);
 
   const ref = useOnclickOutside(() => {
     setIsPlaylistMenuOpen(false);
   });
 
   useEffect(() => {
+    scrollToTop();
     getSingleVideoHandler(videoID).then((videoResponse) => {
       setVideo(videoResponse);
       setIsLiked(isLiked(videoResponse, likesState.likes));
-      addToHistoryHandler(videoResponse, historyDispatch, authState.token);
+      setInWatchlater(
+        isInWatchlater(videoResponse, watchlaterState.watchlater)
+      );
+      if (authState.token) {
+        addToHistoryHandler(videoResponse, historyDispatch, authState.token);
+      }
     });
   }, [videoID]);
 
@@ -78,12 +95,27 @@ const SingleVideoPage = () => {
                   <Icon icon={isVideoLiked ? icons.liked : icons.like} />
                   <p className={styles.value}>{video.likes}</p>
                 </button>
-                <span
-                  className={`${styles.valueWrapper} ${styles.bookmarkIcon}`}
+                <button
+                  className={`${styles.valueWrapper} ${styles.bookmarkIcon} ${
+                    inWatchlater ? styles.liked : null
+                  }`}
+                  onClick={() =>
+                    watchlaterHandler(
+                      authState.token,
+                      componentsDispatch,
+                      watchlaterDispatch,
+                      inWatchlater,
+                      setInWatchlater,
+                      video,
+                      ""
+                    )
+                  }
                 >
-                  <Icon icon={icons.bookmarked} />
+                  <Icon
+                    icon={inWatchlater ? icons.bookmarked : icons.bookmark}
+                  />
                   <p className={styles.value}>Watchlater</p>
-                </span>
+                </button>
                 <button
                   className={`${styles.valueWrapper} ${styles.playlistIcon}`}
                   onClick={() =>

--- a/src/screens/Watchlater.jsx
+++ b/src/screens/Watchlater.jsx
@@ -1,14 +1,42 @@
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
 import { InfoSidebar, HorizontalCardWrapper } from "../components";
-import { videos } from "../backend/db/videos";
+import { useWatchlater } from "../context";
+import { scrollToTop } from "../utilities";
 import styles from "./Watchlater.module.css";
 
 const Watchlater = () => {
-  const videoList = videos.slice(1, 4);
+  const { watchlaterState } = useWatchlater();
+
+  useEffect(scrollToTop, []);
+
   return (
     <section className={styles.body}>
       <div className={styles.watchlaterWrapper}>
-        <InfoSidebar page="Watch Later" noOfVideos={videoList.length} />
-        <HorizontalCardWrapper videoList={videoList} page="watchlater" />
+        <InfoSidebar
+          page="Watch Later"
+          noOfVideos={watchlaterState.watchlater.length}
+        />
+        {watchlaterState.watchlater.length > 0 ? (
+          <HorizontalCardWrapper
+            videoList={watchlaterState.watchlater}
+            page="watchlater"
+          />
+        ) : (
+          <div className={styles.emptyWatchlaterMsgWrapper}>
+            <p className={styles.emptyWatchlaterMsg}>
+              Do you wish to see some video later?
+              <br />
+              Then go and add them to watchlater <br />
+              🙃
+            </p>
+            <Link to="/explore">
+              <button className="button btn-solid-primary">
+                Explore Videos
+              </button>
+            </Link>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/screens/Watchlater.module.css
+++ b/src/screens/Watchlater.module.css
@@ -11,6 +11,24 @@
   padding: var(--space-md);
 }
 
+.emptyWatchlaterMsg {
+  align-items: center;
+  display: flex;
+  font-size: var(--fs-lg-1);
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+}
+
+.emptyWatchlaterMsgWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.emptyWatchlaterMsgWrapper > a {
+  margin: auto;
+}
+
 /*
 ***************** MEDIA QUERIES *****************
 */

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,12 @@ import {
   removeVideoFromPlaylistHandler,
 } from "./backend/controllers/PlaylistController";
 import { users } from "./backend/db/users";
+import {
+  addItemToWatchLaterVideos,
+  getWatchLaterVideosHandler,
+  removeItemFromWatchLaterVideos,
+} from "./backend/controllers/WatchLaterController";
+
 export function makeServer({ environment = "development" } = {}) {
   return new Server({
     serializers: {
@@ -47,6 +53,7 @@ export function makeServer({ environment = "development" } = {}) {
       like: Model,
       history: Model,
       playlist: Model,
+      watchlater: Model,
     },
 
     // Runs on the start of the server
@@ -60,6 +67,7 @@ export function makeServer({ environment = "development" } = {}) {
         server.create("user", {
           ...item,
           likes: [],
+          watchlater: [],
           history: [],
           playlists: [],
         })
@@ -86,6 +94,14 @@ export function makeServer({ environment = "development" } = {}) {
       this.get("/user/likes", getLikedVideosHandler.bind(this));
       this.post("/user/likes", addItemToLikedVideos.bind(this));
       this.delete("/user/likes/:videoId", removeItemFromLikedVideos.bind(this));
+
+      // watch later routes (private)
+      this.get("/user/watchlater", getWatchLaterVideosHandler.bind(this));
+      this.post("/user/watchlater", addItemToWatchLaterVideos.bind(this));
+      this.delete(
+        "/user/watchlater/:videoId",
+        removeItemFromWatchLaterVideos.bind(this)
+      );
 
       // playlist routes (private)
       this.get("/user/playlists", getAllPlaylistsHandler.bind(this));

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -23,3 +23,9 @@ export {
   removeFromPlaylistsService,
   removeVideoFromPlaylistsService,
 } from "./playlists";
+
+export {
+  addToWatchlaterService,
+  getWatchlaterService,
+  removeFromWatchlaterService,
+} from "./watchlater";

--- a/src/services/watchlater/addToWatchlater.service.js
+++ b/src/services/watchlater/addToWatchlater.service.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+const addToWatchlaterService = (video, token) => {
+  return axios.post(
+    "/api/user/watchlater",
+    { video },
+    {
+      headers: { authorization: token },
+    }
+  );
+};
+
+export { addToWatchlaterService };

--- a/src/services/watchlater/getWatchlater.service.js
+++ b/src/services/watchlater/getWatchlater.service.js
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+const getWatchlaterService = (token) => {
+  return axios.get("/api/user/watchlater", {
+    headers: {
+      authorization: token,
+    },
+  });
+};
+
+export { getWatchlaterService };

--- a/src/services/watchlater/index.js
+++ b/src/services/watchlater/index.js
@@ -1,0 +1,3 @@
+export { addToWatchlaterService } from "./addToWatchlater.service";
+export { getWatchlaterService } from "./getWatchlater.service";
+export { removeFromWatchlaterService } from "./removeFromWatchlater.service";

--- a/src/services/watchlater/removeFromWatchlater.service.js
+++ b/src/services/watchlater/removeFromWatchlater.service.js
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const removeFromWatchlaterService = (videoId, token) => {
+  return axios.delete(`/api/user/watchlater/${videoId}`, {
+    headers: { authorization: token },
+  });
+};
+
+export { removeFromWatchlaterService };

--- a/src/utilities/auth/loginHandler.js
+++ b/src/utilities/auth/loginHandler.js
@@ -3,6 +3,7 @@ import {
   getHistoryService,
   getLikesService,
   getPlaylistsService,
+  getWatchlaterService,
 } from "../../services";
 import { Alert } from "../../components";
 
@@ -13,6 +14,7 @@ const loginHandler = async (
   historyDispatch,
   likesDispatch,
   playlistsDispatch,
+  watchlaterDispatch,
   event
 ) => {
   event.preventDefault();
@@ -66,6 +68,15 @@ const loginHandler = async (
         type: "INITIAL_PLAYLISTS",
         payload: {
           playlists: responsePlaylists.data.playlists,
+        },
+      });
+      const responseWatchlater = await getWatchlaterService(
+        response.data.encodedToken
+      );
+      watchlaterDispatch({
+        type: "INITIAL_WATCHLATER",
+        payload: {
+          watchlater: responseWatchlater.data.watchlater,
         },
       });
       componentsDispatch({

--- a/src/utilities/auth/logoutHandler.js
+++ b/src/utilities/auth/logoutHandler.js
@@ -6,6 +6,7 @@ const logoutHandler = (
   historyDispatch,
   playlistDispatch,
   componentsDispatch,
+  watchlaterDispatch,
   navigate
 ) => {
   componentsDispatch({
@@ -28,6 +29,9 @@ const logoutHandler = (
   });
   playlistDispatch({
     type: "CLEAR_PLAYLIST",
+  });
+  watchlaterDispatch({
+    type: "RESET_WATCHLATER",
   });
   componentsDispatch({
     type: "LOADER",

--- a/src/utilities/history/addToHistoryHandler.js
+++ b/src/utilities/history/addToHistoryHandler.js
@@ -12,7 +12,7 @@ const addToHistoryHandler = async (video, historyDispatch, token) => {
       });
     }
   } catch (error) {
-    console.log(error.response);
+    console.log(error);
   }
 };
 

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,8 +1,8 @@
 export { loginHandler, logoutHandler, guestUser, signupHandler } from "./auth";
 
 export {
-  clearHistoryHandler,
   addToHistoryHandler,
+  clearHistoryHandler,
   removeFromHistoryHandler,
 } from "./history";
 
@@ -13,7 +13,7 @@ export {
   removeFromLikesHandler,
 } from "./likes";
 
-export { icons, inputHandler, tabsList } from "./misc";
+export { icons, inputHandler, tabsList, scrollToTop } from "./misc";
 
 export {
   addToPlaylistsHandler,
@@ -23,3 +23,10 @@ export {
 } from "./playlists";
 
 export { getSingleVideoHandler } from "./videos";
+
+export {
+  addToWatchlaterHandler,
+  isInWatchlater,
+  removeFromWatchlaterHandler,
+  watchlaterHandler,
+} from "./watchlater";

--- a/src/utilities/misc/index.js
+++ b/src/utilities/misc/index.js
@@ -1,3 +1,4 @@
 export { icons } from "./icons";
 export { inputHandler } from "./inputHandler";
+export { scrollToTop } from "./scrollToTop";
 export { tabsList } from "./tabsList";

--- a/src/utilities/misc/scrollToTop.js
+++ b/src/utilities/misc/scrollToTop.js
@@ -1,0 +1,5 @@
+const scrollToTop = () => {
+  document.querySelector("#mainBody").scrollTo(0, 0);
+};
+
+export { scrollToTop };

--- a/src/utilities/watchlater/addToWatchlaterHandler.js
+++ b/src/utilities/watchlater/addToWatchlaterHandler.js
@@ -1,0 +1,21 @@
+import { addToWatchlaterService } from "../../services";
+
+const addToWatchlaterHandler = async (video, watchlaterDispatch, token) => {
+  try {
+    const response = await addToWatchlaterService(video, token);
+    if (response.status === 201) {
+      watchlaterDispatch({
+        type: "ADD_TO_WATCHLATER",
+        payload: {
+          watchlater: response.data.watchlater.reverse(),
+        },
+      });
+    } else {
+      throw new Error("Something went wrong. Please try again later!");
+    }
+  } catch (error) {
+    alert(error);
+  }
+};
+
+export { addToWatchlaterHandler };

--- a/src/utilities/watchlater/index.js
+++ b/src/utilities/watchlater/index.js
@@ -1,0 +1,4 @@
+export { addToWatchlaterHandler } from "./addToWatchlaterHandler";
+export { isInWatchlater } from "./isInWatchlater";
+export { removeFromWatchlaterHandler } from "./removeFromWatchlaterHandler";
+export { watchlaterHandler } from "./watchlaterHandler";

--- a/src/utilities/watchlater/isInWatchlater.js
+++ b/src/utilities/watchlater/isInWatchlater.js
@@ -1,0 +1,7 @@
+const isInWatchlater = (video, watchlaterVideos) => {
+  return watchlaterVideos.find((currVideo) => currVideo._id === video._id)
+    ? true
+    : false;
+};
+
+export { isInWatchlater };

--- a/src/utilities/watchlater/removeFromWatchlaterHandler.js
+++ b/src/utilities/watchlater/removeFromWatchlaterHandler.js
@@ -1,0 +1,57 @@
+import { Alert } from "../../components";
+import { removeFromWatchlaterService } from "../../services";
+
+const removeFromWatchlaterHandler = async (
+  videoId,
+  watchlaterDispatch,
+  componentsDispatch,
+  token,
+  page = ""
+) => {
+  if (page === "watchlater") {
+    componentsDispatch({
+      type: "LOADER",
+      payload: {
+        active: true,
+        title: "Removing from Watchlater",
+      },
+    });
+  }
+  try {
+    const response = await removeFromWatchlaterService(videoId, token);
+    if (response.status === 200) {
+      watchlaterDispatch({
+        type: "REMOVE_FROM_WATCHLATER",
+        payload: {
+          watchlater: response.data.watchlater.reverse(),
+        },
+      });
+      componentsDispatch({
+        type: "LOADER",
+        payload: {
+          active: false,
+          title: "",
+        },
+      });
+    }
+  } catch (error) {
+    componentsDispatch({
+      type: "LOADER",
+      payload: {
+        active: false,
+        title: "",
+      },
+    });
+    componentsDispatch({
+      type: "ALERT",
+      payload: {
+        active: true,
+        child: (
+          <Alert action="danger" message={error.response.data.errors[0]} />
+        ),
+      },
+    });
+  }
+};
+
+export { removeFromWatchlaterHandler };

--- a/src/utilities/watchlater/watchlaterHandler.js
+++ b/src/utilities/watchlater/watchlaterHandler.js
@@ -1,0 +1,41 @@
+import {
+  addToWatchlaterHandler,
+  removeFromWatchlaterHandler,
+} from "../../utilities";
+import { LoginModal } from "../../components";
+
+const watchlaterHandler = (
+  token,
+  componentsDispatch,
+  watchlaterDispatch,
+  isVideoInWatchlater,
+  setIsInWatchlater,
+  video,
+  page
+) => {
+  if (token) {
+    if (isVideoInWatchlater) {
+      setIsInWatchlater(false);
+      return removeFromWatchlaterHandler(
+        video._id,
+        watchlaterDispatch,
+        componentsDispatch,
+        token,
+        page
+      );
+    } else {
+      setIsInWatchlater(true);
+      return addToWatchlaterHandler(video, watchlaterDispatch, token);
+    }
+  }
+  return componentsDispatch({
+    type: "MODAL",
+    payload: {
+      active: true,
+      child: <LoginModal />,
+      title: "Login",
+    },
+  });
+};
+
+export { watchlaterHandler };


### PR DESCRIPTION
### 📝 Description

Watch later is a list of videos that the user can save for watching videos later or for future reference.

### 🚀 New behavior

The user can now
- Add Videos to watchlater
- Remove them from watchlater
- Remove all videos from watchlater
- Remove all videos from history
- Remove all videos from likes

### 🖼 Preview Link

https://vistream-react-version-6w73cupan-vishalpatil18.vercel.app/

### 💣 Is this a breaking change?
- [ ] Yes
- [x] No

### 🔬 Is the code self-reviewed?
- [x] Yes
- [ ] No

### 📋 Is the code well-formatted?
- [x] Yes
- [ ] No


### 🔗 Related to Issue 
- #25 

> NOTE: Trending videos is not yet implemented on the home page